### PR TITLE
Get superseded eligibility

### DIFF
--- a/app/Http/Controllers/StatuteController.php
+++ b/app/Http/Controllers/StatuteController.php
@@ -155,7 +155,6 @@ class StatuteController extends Controller
         }
 
         if ($statute = $this->sanitizeAndFind($id)) {
-            dd($statute);
             $can_edit = Auth::user()->can('statute edit');
             $can_delete = Auth::user()->can('statute delete') && $statute->canDelete();
             $charges = $statute->getCharges($id);

--- a/app/Http/Controllers/StatuteController.php
+++ b/app/Http/Controllers/StatuteController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Middleware\TrimStrings;
 use App\Statute;
+use App\StatutesEligibility;
 use Illuminate\Http\Request;
 
 use App\Http\Requests\StatuteFormRequest;
@@ -154,6 +155,7 @@ class StatuteController extends Controller
         }
 
         if ($statute = $this->sanitizeAndFind($id)) {
+            dd($statute);
             $can_edit = Auth::user()->can('statute edit');
             $can_delete = Auth::user()->can('statute delete') && $statute->canDelete();
             $charges = $statute->getCharges($id);
@@ -290,7 +292,13 @@ class StatuteController extends Controller
      */
     private function sanitizeAndFind($id)
     {
-        return \App\Statute::with('statutes_eligibility','superseded')->find(intval($id));
+        return \App\Statute::with([
+            'statutes_eligibility',
+            'superseded' => function ($q) {
+                $q->with('statutes_eligibility');
+            }
+        ])
+            ->find(intval($id));
     }
 
 
@@ -413,4 +421,6 @@ class StatuteController extends Controller
         }
         return $statutes->get();
     }
+
+
 }

--- a/app/Statute.php
+++ b/app/Statute.php
@@ -269,4 +269,28 @@ class Statute extends Model
 
     }
 
+    public function scopeWithEligibility($builder)
+    {
+        // check if the selects are loaded if not load them
+        if (is_null($builder->getQuery()->columns)) {
+            $builder->select('statutes.*');
+        }
+
+        // build subquery to join eligibility status and select name as eligibility
+        $query = StatutesEligibility::select('name')
+            ->whereColumn('statutes.statutes_eligibility_id', 'statutes_eligibilities.id');
+
+        return $builder->selectSub($query->limit(1), 'eligibility');
+    }
+
+    public function scopeWithSuperseded($query)
+    {
+        $query->withEligibility()
+            ->with([
+                'superseded' => function ($q) {
+                    $q->withEligibility();
+            }
+        ]);
+    }
+
 }


### PR DESCRIPTION
I added changed the query in statutes controller to get the superseded eligibility as a relationship.
```
$statute = \App\Statute::with([
            'statutes_eligibility',
            'superseded' => function ($q) {
                $q->with('statutes_eligibility');
            }
        ])

$statute->superseded->statutes_eligibility->name
```
I added another option that might be easier as well. I added 2 scopes to the Statute class. One to get the eligibility status and add it the select so it can be accessed like a property. 
```
$statute = Statute::withEligibility()->find(222) 
$statute->eligibility 
```

The other allows you to get the statute with eligibility as well as the superseded with eligibility.
```
$statute = Statute::withSuperseded()->find(222)
$statute->superseded->eligibility 
```
#104 